### PR TITLE
대출 가능 여부에 따른 3-시나리오 출력 필터링 구현

### DIFF
--- a/backend/app/services/loan_availability.py
+++ b/backend/app/services/loan_availability.py
@@ -15,11 +15,6 @@ import requests
 
 BOOK_EXIST_URL = "http://data4library.kr/api/bookExist"
 
-
-# --------------------------------------------------
-# 1. 단건 조회
-# --------------------------------------------------
-
 def check_loan_availability(
     isbn: str,
     lib_code: str,
@@ -62,11 +57,6 @@ def check_loan_availability(
             "error": str(exc),
         }
 
-
-# --------------------------------------------------
-# 2. 배치 조회
-# --------------------------------------------------
-
 def check_books_availability(
     isbns: List[str],
     lib_code: str,
@@ -74,22 +64,12 @@ def check_books_availability(
 ) -> Dict[str, Dict[str, Any]]:
     """
     ISBN 목록에 대해 일괄로 대출 가능 여부를 조회한다.
-
-    반환 예시:
-    {
-        "9788937473135": {"isbn": "...", "has_book": "Y", "loan_available": "N"},
-        ...
-    }
     """
     availability_index: Dict[str, Dict[str, Any]] = {}
     for isbn in isbns:
         availability_index[isbn] = check_loan_availability(isbn, lib_code, auth_key)
     return availability_index
 
-
-# --------------------------------------------------
-# 3. 결과 출력 헬퍼
-# --------------------------------------------------
 
 def print_results_with_availability(
     reranked_books: List[Dict[str, Any]],
@@ -125,11 +105,6 @@ def print_results_with_availability(
         print(f"       최종점수: {book.get('final_score', '-')}")
         print(f"       대출현황: {avail_str}")
         print()
-
-
-# --------------------------------------------------
-# 4. 실행 예시
-# --------------------------------------------------
 
 if __name__ == "__main__":
     import json

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -75,26 +75,45 @@ class PipelineResult:
     @property
     def final_results(self) -> list[dict]:
         """
-        최종 결과 반환
+        최종 결과 반환 — 3-시나리오 필터링
 
-        availability_required=True 인 경우 대출 불가 도서 제외
-        reranked_results 있으면 reranked, 없으면 bm25_results 사용
+        availability_index 없음 → Top3 그대로 반환
+        [Scenario C] availability_required=True → 대출가능 Top3만
+        [Scenario A] 1등 대출가능              → 대출가능 Top3만
+        [Scenario B] 1등 대출불가              → 대출가능 Top3 + 1등 추가
         """
         base = self.reranked_results if self.reranked_results else self.bm25_results
 
         if not self.availability_index:
-            return base
+            return base[:3]
 
-        # 대출 가능 여부 정보 붙이기
-        result = []
+        # 대출 가능 여부 정보 부착
+        books_with_avail = []
         for book in base:
             isbn  = book.get("isbn", "")
             avail = self.availability_index.get(isbn, {})
-            result.append({
+            books_with_avail.append({
                 **book,
                 "has_book"      : avail.get("has_book", "-"),
                 "loan_available": avail.get("loan_available", "-"),
             })
+
+        available = [b for b in books_with_avail if b.get("loan_available") == "Y"]
+        top3      = available[:3]
+
+        # [Scenario C]
+        if self.availability_required:
+            return top3
+
+        # [Scenario A] 1등이 대출가능이면 Top3만
+        rank1 = books_with_avail[0] if books_with_avail else None
+        if not rank1 or rank1.get("loan_available") == "Y":
+            return top3
+
+        # [Scenario B] 1등이 대출불가면 Top3 + 1등 추가
+        result = list(top3)
+        if rank1 not in result:
+            result.append(rank1)
         return result
 
 
@@ -286,10 +305,9 @@ async def run_full_pipeline(
         rag_query    = result.rag_query,
     )
 
-    # [5] 대출 가능 여부 조회
-    # availability_required=True 면 항상 조회
-    # False 면 조회는 하되 final_results에서 필터링은 안 함 (표시만)
-    candidate_books = result.reranked_results or result.bm25_results
+    # [5] 대출 가능 여부 조회 — 리랭킹 Top10 대상
+    candidate_books = (result.reranked_results or result.bm25_results)[:10]
+    result.availability_required = context.slots.availability_required
     result.availability_index = run_availability(
         books        = candidate_books,
         lib_code     = lib_code,


### PR DESCRIPTION
## 작업 내용
`pipeline.py` 내의 loan_availability 로직을 수정했습니다.

## 변경 사항
- 리랭킹 결과 Top5 확정 후 대출 가능 여부를 확인하도록 수정
- 리랭킹 1등 도서가 대출 가능하면 대출 가능한 Top3만 출력
- 리랭킹 1등 도서가 대출 불가능하면 대출 가능한 Top3와 함께 리랭킹 1등 도서를 추가 출력
- 사용자가 “지금 당장 대출 가능”처럼 명시 요청한 경우에는 대출 가능한 도서만 출력